### PR TITLE
Add `ensureGraphUniqueness` to be run before user edits and insertion

### DIFF
--- a/poly-graph-persistent/poly-graph-persistent.cabal
+++ b/poly-graph-persistent/poly-graph-persistent.cabal
@@ -17,10 +17,12 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.Graph.HGraph.Persistent
                      , Data.Graph.HGraph.Persistent.Instances
+                     , Data.Graph.HGraph.Persistent.TH
   build-depends:       base >= 4.7 && < 5
                      , poly-graph
                      , transformers
                      , persistent
+                     , persistent-template
                      , tagged
                      , generics-eot
                      , QuickCheck
@@ -28,6 +30,7 @@ library
                      , semigroups
                      , text
                      , containers
+                     , template-haskell
   default-language:    Haskell2010
 
 test-suite test

--- a/poly-graph-persistent/poly-graph-persistent.cabal
+++ b/poly-graph-persistent/poly-graph-persistent.cabal
@@ -26,6 +26,8 @@ library
                      , QuickCheck
                      , lens
                      , semigroups
+                     , text
+                     , containers
   default-language:    Haskell2010
 
 test-suite test

--- a/poly-graph-persistent/poly-graph-persistent.cabal
+++ b/poly-graph-persistent/poly-graph-persistent.cabal
@@ -25,6 +25,7 @@ library
                      , generics-eot
                      , QuickCheck
                      , lens
+                     , semigroups
   default-language:    Haskell2010
 
 test-suite test

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
@@ -281,7 +281,7 @@ instance
   ) => EnsureUniqueness (f a) (f (Entity a)) as where
   ensureUniqueness fa graph = do
     fa' <- traverse (`ensureUniqueness` graph) fa
-    if isInternallyConsistent fa'
+    if doesNodeSatisfyUniqueness fa'
       then pure fa'
       else do
         fa'' <- traverse (const arbitrary) fa' -- This could be less drastic
@@ -289,7 +289,7 @@ instance
 
 -- | Check that a context-free value is internally consistent
 class DoesNodeSatisfyUniqueness a b | a -> b, b -> a where
-  isInternallyConsistent :: a -> Bool
+  doesNodeSatisfyUniqueness :: a -> Bool
 
 -- | Collections of entities should not have duplicates
 instance
@@ -297,7 +297,7 @@ instance
   , PersistEntity a
   , UniquenessCheck a
   ) => DoesNodeSatisfyUniqueness (f a) (f (Entity a)) where
-  isInternallyConsistent fa =
+  doesNodeSatisfyUniqueness fa =
     length (List.nubBy couldCauseUniquenessViolation items) == length items
    where
     items = toList fa

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
@@ -263,13 +263,12 @@ instance
   , Arbitrary a
   , UniquenessCheck a
   ) => EnsureUniqueness a (Entity a) as where
-  ensureUniqueness a graph = do
-    let others = getAllOfType graph
-    if any (couldCauseUniquenessViolation a) others
-      then do
-        new <- arbitrary
-        ensureUniqueness new graph
-      else pure a
+  ensureUniqueness a0 graph =
+    loop (getAllOfType graph) a0
+   where
+    loop others a
+      | any (couldCauseUniquenessViolation a) others = arbitrary >>= loop others
+      | otherwise = pure a
 
 -- | Check uniqueness by looking inside Functor-shaped values and ensuring
 -- that the values in the Functor itself are unique together

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
@@ -276,7 +276,7 @@ instance
   ( Wrap a ~ Entity a
   , Traversable f
   , EnsureUniqueness a (Entity a) as
-  , IsInternallyConsistent (f a) (f (Entity a))
+  , DoesNodeSatisfyUniqueness (f a) (f (Entity a))
   , Arbitrary a
   ) => EnsureUniqueness (f a) (f (Entity a)) as where
   ensureUniqueness fa graph = do
@@ -288,7 +288,7 @@ instance
         ensureUniqueness fa'' graph
 
 -- | Check that a context-free value is internally consistent
-class IsInternallyConsistent a b | a -> b, b -> a where
+class DoesNodeSatisfyUniqueness a b | a -> b, b -> a where
   isInternallyConsistent :: a -> Bool
 
 -- | Collections of entities should not have duplicates
@@ -296,7 +296,7 @@ instance
   ( Foldable f
   , PersistEntity a
   , UniquenessCheck a
-  ) => IsInternallyConsistent (f a) (f (Entity a)) where
+  ) => DoesNodeSatisfyUniqueness (f a) (f (Entity a)) where
   isInternallyConsistent fa =
     length (List.nubBy couldCauseUniquenessViolation items) == length items
    where

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Data.Graph.HGraph.Persistent.TH
+  ( UniquenessCheck(..)
+  , mkUniquenessChecks
+  , mkUniquenessCheck
+  ) where
+
+import Control.Arrow ((&&&))
+import Data.Char (toLower, toUpper)
+import Data.List.NonEmpty (nonEmpty)
+import Data.Map.Strict (Map)
+import qualified Data.Map.Strict as Map
+import Data.Maybe (mapMaybe)
+import Data.Monoid ((<>))
+import Data.Text (Text, unpack, cons, uncons)
+import Database.Persist
+import Database.Persist.TH
+import Language.Haskell.TH
+
+class UniquenessCheck a where
+  couldCauseUniquenessViolation :: a -> a -> Bool
+
+mkUniquenessChecks :: MkPersistSettings -> [EntityDef] -> Q [Dec]
+mkUniquenessChecks settings = fmap concat . traverse (mkUniquenessCheck settings)
+
+mkUniquenessCheck :: MkPersistSettings -> EntityDef -> Q [Dec]
+mkUniquenessCheck settings EntityDef{..} =
+  [d|
+    instance UniquenessCheck $typeName where
+      couldCauseUniquenessViolation $lhs $rhs = $expr
+  |]
+ where
+  lhs = pure $ VarP $ mkName "lhs"
+  rhs = pure $ VarP $ mkName "rhs"
+
+  unHaskelled = unHaskellName entityHaskell
+  typeName = conT $ mkName $ unpack unHaskelled
+
+  nameToRef = Map.fromList ((fieldHaskell &&& fieldReference) <$> entityFields)
+  expr = pure $ mkOrExpr mkSelector nameToRef entityUniques
+
+  mkSelector = mkName . unpack . maybeUnderscore . maybePrefixed
+  maybeUnderscore fieldName
+   | mpsGenerateLenses settings = '_' `cons` fieldName
+   | otherwise = fieldName
+  maybePrefixed fieldName
+   | mpsPrefixFields settings = lowerFirst unHaskelled <> upperFirst (unHaskellName fieldName)
+   | otherwise = unHaskellName fieldName
+
+lowerFirst :: Text -> Text
+lowerFirst t =
+  case uncons t of
+    Just (c, cs) -> cons (toLower c) cs
+    Nothing -> t
+
+upperFirst :: Text -> Text
+upperFirst t =
+  case uncons t of
+    Just (c, cs) -> cons (toUpper c) cs
+    Nothing -> t
+
+mkOrExpr :: (HaskellName -> Name) -> Map HaskellName ReferenceDef -> [UniqueDef] -> Exp
+mkOrExpr mkSelector nameToRef uniqueDefs =
+  maybe
+    false
+    (foldl1 $ binApp orOp)
+    (nonEmpty andExprs)
+ where
+  false = ConE $ mkName "False"
+  orOp = VarE $ mkName "||"
+  andExprs = mapMaybe (mkAndExpr mkSelector nameToRef) uniqueDefs
+
+mkAndExpr :: (HaskellName -> Name) -> Map HaskellName ReferenceDef -> UniqueDef -> Maybe Exp
+mkAndExpr mkSelector nameToRef UniqueDef{..} =
+  foldl1 (binApp andOp) <$> nonEmpty comparisons
+ where
+  andOp = VarE $ mkName "&&"
+  fields = map fst uniqueFields
+  nonForeignFields = filter (not . isForeignRef . (nameToRef Map.!)) fields
+  comparisons = map (mkComparison . mkSelector) nonForeignFields
+
+mkComparison :: Name -> Exp
+mkComparison selector =
+  binApp eqOp (VarE selector `AppE` lhs) (VarE selector `AppE` rhs)
+ where
+  eqOp = VarE $ mkName "=="
+  lhs = VarE $ mkName "lhs"
+  rhs = VarE $ mkName "rhs"
+
+binApp :: Exp -> Exp -> Exp -> Exp
+binApp f x y = UInfixE x f y
+
+isForeignRef :: ReferenceDef -> Bool
+isForeignRef ForeignRef{} = True
+isForeignRef _ = False

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH.hs
@@ -28,8 +28,8 @@ mkUniquenessChecks settings = fmap concat . traverse (mkUniquenessCheck settings
 
 mkUniquenessCheck :: MkPersistSettings -> EntityDef -> Q [Dec]
 mkUniquenessCheck settings def = do
-  lhs <- newName "lhs"
-  rhs <- newName "rhs"
+  lhs <- newName "_lhs"
+  rhs <- newName "_rhs"
   mkUniquenessCheckWithOperands settings def (lhs, rhs)
 
 mkUniquenessCheckWithOperands :: MkPersistSettings -> EntityDef -> (Name, Name) -> Q [Dec]

--- a/poly-graph-persistent/test/Spec.hs
+++ b/poly-graph-persistent/test/Spec.hs
@@ -122,10 +122,10 @@ share [mkUniquenessChecks sqlSettings { mpsGenerateLenses = True }, mkPersist sq
     name Text
     bar Bool
     baz Bool
-    whomp Bool
+    whomp Bool Maybe
     foo FooId
     UniqueFooBarBaz foo bar baz -- A nonsensical constraint that has an FK and two plain values
-    UniqueWhomp whomp -- A second constraint
+    UniqueWhomp whomp !force -- A second constraint with a nullable field
     deriving Show Eq Generic
 |]
 

--- a/poly-graph-persistent/test/Spec.hs
+++ b/poly-graph-persistent/test/Spec.hs
@@ -279,6 +279,24 @@ main = do
                     ]
                  )
         pure ()
+      it "works with unique constraints and unique if the latter is used carefully" $ db $ do
+        graph <-
+          liftIO (generate (unique fooName =<< ensureGraphUniqueness =<< fmap unRawGraph arbitrary))
+            :: M (
+                 HGraph
+                   '[ '("Foo1", '[], Foo)
+                    , '("Foo2", '[], Foo)
+                    ]
+                 )
+        graph' <-
+          insertGraph graph
+            :: M (
+                 HGraph
+                   '[ '("Foo1", '[], Entity Foo)
+                    , '("Foo2", '[], Entity Foo)
+                    ]
+                 )
+        pure ()
       it "ensures internal uniqueness in a single node" $ db $ do
         graph <-
           liftIO (generate (ensureGraphUniqueness =<< fmap unRawGraph arbitrary))

--- a/poly-graph-persistent/test/Spec2.hs
+++ b/poly-graph-persistent/test/Spec2.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -105,13 +104,6 @@ share [mkPersist sqlSettings { mpsGenerateLenses = True },  mkMigrate "testMigra
     schoolId  SchoolId
     deriving Show Eq Generic
 |]
-
-deriving instance Eq (Unique District)
-deriving instance Eq (Unique School)
-deriving instance Eq (Unique Teacher)
-deriving instance Eq (Unique Student)
-deriving instance Eq (Unique MultiPointer)
-
 instance Arbitrary District where
   arbitrary = District <$> arbitrary <*> arbitrary
 instance Arbitrary School where

--- a/poly-graph-persistent/test/Spec2.hs
+++ b/poly-graph-persistent/test/Spec2.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -104,6 +105,13 @@ share [mkPersist sqlSettings { mpsGenerateLenses = True },  mkMigrate "testMigra
     schoolId  SchoolId
     deriving Show Eq Generic
 |]
+
+deriving instance Eq (Unique District)
+deriving instance Eq (Unique School)
+deriving instance Eq (Unique Teacher)
+deriving instance Eq (Unique Student)
+deriving instance Eq (Unique MultiPointer)
+
 instance Arbitrary District where
   arbitrary = District <$> arbitrary <*> arbitrary
 instance Arbitrary School where


### PR DESCRIPTION
Hey Eric - we've been experiencing more random failures due to uniqueness constraints not being taken into account. This is just a proof-of-concept so far.

We check that for each `a` we insert, `Unique a` is not duplicated in the segment of the graph that's already been inserted. This works, but it means edits to the non-`Entity` version of the graph can be overwritten by `arbitrary`:

```haskell
graph <-
  liftIO (generate arbitrary)
    <&> pluck $(sym "me") . nameLens .~ "Joe"
    <&> unRawGraph
    -- Edits happen here, but FKs haven't been updated yet, so checking uniqueness
    -- doesn't make any sense

graph' <-
  insertGraph graph
    :: M
      ( HGraph
        '[ '("me", '["address"], Entity Person)
         , '("you", '[], Entity Person)
         , '("address", '[], Entity Address)
         ])
    -- Easy to check uniqueness here (incrementally!), but if we use arbitrary to re-generate
    -- duplicates, we overwrite edits
```

I was thinking it might be possible to generate code to only update the fields in a value that are specified by the uniqueness constraint. For example, given:

```haskell
share [mkPersist sqlSettings { mpsGenerateLenses = True },  mkMigrate "testMigrate"] [persistLowerCase|
  ...
  Foo
    name Text
    ...
    bar Bool
    BarUnique bar
    deriving Show Eq Generic
|]
```

This generates a data instance:
```haskell
data instance Unique Foo = BarUnique Bool
```

But maybe we could generate something like:
```
class UpdateUnique a where
  updateUnique :: a -> Unique a -> a

instance UpdateUnique Foo where
  updateUnique foo (BarUnique bar) = foo { fooBar = bar }
```

Another option might be to ignore fields in the `Unique a` that _aren't_ foreign-keys, and do the check before insertion. I haven't really figured out if this is sound or not.

Thoughts?