### PR TITLE
Add mkUniquenessChecks[For] and upgrade to lts-8.8

### DIFF
--- a/poly-graph-persistent/poly-graph-persistent.cabal
+++ b/poly-graph-persistent/poly-graph-persistent.cabal
@@ -37,6 +37,8 @@ test-suite test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Spec.hs
+  other-modules:       Common
+                       External
   build-depends:       base
                      , poly-graph
                      , poly-graph-persistent

--- a/poly-graph-persistent/poly-graph-persistent.cabal
+++ b/poly-graph-persistent/poly-graph-persistent.cabal
@@ -18,6 +18,7 @@ library
   exposed-modules:     Data.Graph.HGraph.Persistent
                      , Data.Graph.HGraph.Persistent.Instances
                      , Data.Graph.HGraph.Persistent.TH
+                     , Data.Graph.HGraph.Persistent.TH.Internal
   build-depends:       base >= 4.7 && < 5
                      , poly-graph
                      , transformers
@@ -31,6 +32,7 @@ library
                      , text
                      , containers
                      , template-haskell
+                     , th-expand-syns
   default-language:    Haskell2010
 
 test-suite test

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
@@ -235,7 +235,7 @@ ensureGraphUniqueness
 ensureGraphUniqueness = ensureGraphUniqueness' (Proxy :: Proxy ('[] :: [*]))
 
 class
-  EnsureGraphUniqueness (ps :: [*]) (a :: [(k, [k], *)]) (b :: [(k, [k], *)]) | a -> b, b -> a where
+  EnsureGraphUniqueness (ps :: [*]) (a :: [(k, [k], *)]) (b :: [(k, [k], *)]) where
   ensureGraphUniqueness' :: (WrapAll a ~ b) => Proxy ps -> HGraph a -> Gen (HGraph a)
 
 instance EnsureGraphUniqueness ps '[] '[] where
@@ -253,7 +253,7 @@ instance
     pure $ Node uniqueItem `Cons` uniquedGraph
 
 -- | Update a to be unique in HGraph as
-class EnsureUniqueness a b as | a -> b, b -> a where
+class EnsureUniqueness a b as where
   ensureUniqueness :: (Wrap a ~ b) => a -> HGraph as -> Gen a
 
 -- | Check uniqueness for a by its Uniques modulo FKs

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent.hs
@@ -33,7 +33,7 @@ import Test.QuickCheck.Gen (generate, Gen)
 import Data.Graph.HGraph
 import Data.Graph.HGraph.Instances
 import Data.Graph.HGraph.Internal
-import Data.Graph.HGraph.Persistent.TH (UniquenessCheck(..))
+import Data.Graph.HGraph.Persistent.TH (NullableEqualityModuloFKs(..), couldCauseUniquenessViolation)
 
 instance
   Key a `FieldPointsAt` Entity a where
@@ -261,7 +261,7 @@ instance
   ( PersistEntity a
   , GetAllOfType as a
   , Arbitrary a
-  , UniquenessCheck a
+  , NullableEqualityModuloFKs (Unique a)
   ) => EnsureUniqueness a (Entity a) as where
   ensureUniqueness a0 graph =
     loop (getAllOfType graph) a0
@@ -295,7 +295,7 @@ class DoesNodeSatisfyUniqueness a b | a -> b, b -> a where
 instance
   ( Foldable f
   , PersistEntity a
-  , UniquenessCheck a
+  , NullableEqualityModuloFKs (Unique a)
   ) => DoesNodeSatisfyUniqueness (f a) (f (Entity a)) where
   doesNodeSatisfyUniqueness fa =
     length (List.nubBy couldCauseUniquenessViolation items) == length items

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH/Internal.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH/Internal.hs
@@ -31,7 +31,7 @@ noInstanceYet :: Type -> Q Bool
 noInstanceYet ty = not <$> isInstance ''NullableEqualityModuloFKs [ConT ''Unique `AppT` ty]
 
 unpackDataInstance :: Dec -> (Type, [Con])
-unpackDataInstance (DataInstD _ _ [ty] cons _) = (ty, cons)
+unpackDataInstance (DataInstD _ _ [ty] _ cons _) = (ty, cons)
 unpackDataInstance _ = error "Expected data instance for `Unique`"
 
 mkInstance :: (Type, [Con]) -> Q [Dec]

--- a/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH/Internal.hs
+++ b/poly-graph-persistent/src/Data/Graph/HGraph/Persistent/TH/Internal.hs
@@ -1,0 +1,115 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Data.Graph.HGraph.Persistent.TH.Internal where
+
+import Control.Monad (filterM, when)
+import Data.List.NonEmpty (nonEmpty)
+import Data.Maybe (catMaybes, mapMaybe)
+import Data.Traversable (for)
+import Database.Persist
+import Language.Haskell.TH
+import Language.Haskell.TH.ExpandSyns
+
+-- | 'nullableEqualityModuloFKs' returns 'True' if its arguments
+-- compare equal except on foreign keys and null ('Nothing') components
+class NullableEqualityModuloFKs a where
+  nullableEqualityModuloFKs :: a -> a -> Bool
+
+warnEmpty :: [a] -> Q [a]
+warnEmpty instances = do
+  when (null instances) $
+    reportWarning "`mkUniquenessChecks` used with no Unique data instances in scope"
+  pure instances
+
+availableUniqueInstances :: Q [(Type, [Con])]
+availableUniqueInstances = do
+  FamilyI _ instances <- reify ''Unique
+  filterM (noInstanceYet . fst) $ map unpackDataInstance instances
+
+noInstanceYet :: Type -> Q Bool
+noInstanceYet ty = not <$> isInstance ''NullableEqualityModuloFKs [ConT ''Unique `AppT` ty]
+
+unpackDataInstance :: Dec -> (Type, [Con])
+unpackDataInstance (DataInstD _ _ [ty] cons _) = (ty, cons)
+unpackDataInstance _ = error "Expected data instance for `Unique`"
+
+mkInstance :: (Type, [Con]) -> Q [Dec]
+mkInstance (ty, cons) = do
+  lhs <- newName "_lhs"
+  rhs <- newName "_rhs"
+  branches <- mkExhaustive cons =<< mkBranches cons
+  declareInstance (lhs, rhs) ty (mkBody (lhs, rhs) branches)
+
+mkExhaustive :: [Con] -> [Match] -> Q [Match]
+mkExhaustive [] _ = pure []
+mkExhaustive [_] branches = pure branches
+mkExhaustive _ branches = do
+  wild <- match wildP (normalB $ conE $ 'False) []
+  pure $ branches ++ [wild]
+
+mkBody :: (Name, Name) -> [Match] -> Exp
+mkBody _ [] = ConE $ 'False
+mkBody (lhs, rhs) branches = CaseE (TupE [VarE lhs, VarE rhs]) branches
+
+declareInstance :: (Name, Name) -> Type -> Exp -> Q [Dec]
+declareInstance (lhs, rhs) ty body =
+  [d|
+    instance NullableEqualityModuloFKs (Unique $(pure ty)) where
+      nullableEqualityModuloFKs $(varP lhs) $(varP rhs) = $(pure body)
+  |]
+
+mkBranches :: [Con] -> Q [Match]
+mkBranches = fmap catMaybes . traverse mkBranch
+
+mkBranch :: Con -> Q (Maybe Match)
+mkBranch (NormalC name components) = do
+  binds <- for components $ \(_, ty) -> do
+    lhs <- newName "_lhs"
+    rhs <- newName "_rhs"
+    expanded <- expandSyns ty
+    return (expanded, lhs, rhs)
+  for (mkComparisons binds) $ \comparisons -> do
+    let (_, lhsNames, rhsNames) = unzip3 binds
+    pat <- tupP
+      [ conP name (map varP lhsNames)
+      , conP name (map varP rhsNames)
+      ]
+    pure $ Match pat comparisons []
+mkBranch _ = error "Expected normal constructor for `Unique` data instance constructor"
+
+mkComparisons :: [(Type, Name, Name)] -> Maybe Body
+mkComparisons binds =
+  NormalB . foldl1 (binApp $ VarE $ mkName "&&") <$> nonEmpty (mapMaybe mkComparison binds)
+
+mkComparison :: (Type, Name, Name) -> Maybe Exp
+mkComparison (ty, lhs, rhs) =
+  case ty of
+   AppT (ConT outer) _
+    | outer == ''Key -> Nothing -- ignore foreign keys
+    | outer == ''Maybe -> pure $ mkNonNullEqComparison lhs rhs
+   _ -> pure $ mkEqComparison lhs rhs
+
+mkEqComparison :: Name -> Name -> Exp
+mkEqComparison lhs rhs =
+  binApp
+    (VarE $ mkName "==")
+    (VarE lhs)
+    (VarE rhs)
+
+mkNonNullEqComparison :: Name -> Name -> Exp
+mkNonNullEqComparison lhs rhs =
+  VarE 'maybe
+    `AppE` ConE 'False
+    `AppE` VarE 'id
+    `AppE` ParensE
+      (binApp
+        (VarE $ mkName "<*>")
+        (binApp
+          (VarE $ mkName "<$>")
+          (VarE $ mkName "==")
+          (VarE lhs))
+        (VarE rhs))
+
+binApp :: Exp -> Exp -> Exp -> Exp
+binApp f x y = UInfixE x f y

--- a/poly-graph-persistent/test/Common.hs
+++ b/poly-graph-persistent/test/Common.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Common where
+
+import Data.Maybe (fromMaybe)
+import Data.Proxy (Proxy(..))
+import Data.Text (Text, pack, isSuffixOf)
+import qualified Data.Vector.Sized as Sized
+import Database.Persist
+import Database.Persist.TH
+import GHC.TypeLits (KnownNat, natVal)
+import Test.QuickCheck.Arbitrary (Arbitrary(..), vector)
+
+instance Arbitrary Text where
+  arbitrary = pack . filter (not . isBadChar) <$> arbitrary
+    where isBadChar x = x == '\NUL' || x == '\\' -- Make postgres vomit
+
+instance (KnownNat n, Arbitrary a) => Arbitrary (Sized.Vector n a) where
+  arbitrary =
+    fromMaybe (error "`vector` should return list of requested length") . Sized.fromList <$>
+    vector (fromIntegral (natVal (Proxy :: Proxy n)))
+
+testSettings :: MkPersistSettings
+testSettings = sqlSettings { mpsGenerateLenses = True }
+
+externalFk :: Attr
+externalFk = "external-fk"

--- a/poly-graph-persistent/test/Common.hs
+++ b/poly-graph-persistent/test/Common.hs
@@ -27,6 +27,3 @@ instance (KnownNat n, Arbitrary a) => Arbitrary (Sized.Vector n a) where
 
 testSettings :: MkPersistSettings
 testSettings = sqlSettings { mpsGenerateLenses = True }
-
-externalFk :: Attr
-externalFk = "external-fk"

--- a/poly-graph-persistent/test/External.hs
+++ b/poly-graph-persistent/test/External.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module External where
+
+import Test.Hspec
+
+import Data.Text (Text, pack)
+import Database.Persist
+import Database.Persist.Postgresql
+import Database.Persist.TH
+import GHC.Generics (Generic)
+import Test.QuickCheck.Arbitrary (Arbitrary(..))
+
+import Data.Graph.HGraph.Persistent.TH
+import Common
+
+share [mkUniquenessChecksIgnoring externalFk testSettings, mkPersist testSettings,  mkMigrate "testMigrate"] [persistLowerCase|
+  External
+    name Text
+    position Int
+    UniquePosition position
+    deriving Show Eq Generic
+|]
+
+instance Arbitrary External where
+  arbitrary = External "external" <$> arbitrary

--- a/poly-graph-persistent/test/External.hs
+++ b/poly-graph-persistent/test/External.hs
@@ -21,9 +21,10 @@ import GHC.Generics (Generic)
 import Test.QuickCheck.Arbitrary (Arbitrary(..))
 
 import Data.Graph.HGraph.Persistent.TH
+
 import Common
 
-share [mkUniquenessChecksIgnoring externalFk testSettings, mkPersist testSettings,  mkMigrate "testMigrate"] [persistLowerCase|
+share [mkPersist testSettings,  mkMigrate "testMigrate"] [persistLowerCase|
   External
     name Text
     position Int
@@ -33,3 +34,5 @@ share [mkUniquenessChecksIgnoring externalFk testSettings, mkPersist testSetting
 
 instance Arbitrary External where
   arbitrary = External "external" <$> arbitrary
+
+$(mkUniquenessChecksFor ''External)

--- a/poly-graph-persistent/test/Spec.hs
+++ b/poly-graph-persistent/test/Spec.hs
@@ -79,7 +79,7 @@ resetSequences =
     |]
     []
 
-share [mkUniquenessChecksIgnoring externalFk testSettings, mkPersist testSettings,  mkMigrate "testMigrate"] [persistLowerCase|
+share [mkPersist testSettings,  mkMigrate "testMigrate"] [persistLowerCase|
   SelfRef
     name Text
     selfRefId SelfRefId Maybe
@@ -133,7 +133,7 @@ share [mkUniquenessChecksIgnoring externalFk testSettings, mkPersist testSetting
   Local
     name Text
     flag Bool
-    external ExternalId external-fk
+    external ExternalId
     UniqueFlagExternal flag external -- A constraint pointing at an FK that persistent doesn't know about
     deriving Show Eq Generic
 |]
@@ -175,6 +175,8 @@ instance Baz `PointsAt` Entity Foo
 instance Quux `PointsAt` Entity Foo
 instance Merp `PointsAt` Entity Foo
 instance Local `PointsAt` Entity External
+
+$mkUniquenessChecks
 
 _entityKey :: Lens' (Entity a) (Key a)
 _entityKey pure' (Entity i e) = (\i' -> Entity i' e) <$> pure' i

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,11 +1,6 @@
 packages:
 - poly-graph
 - poly-graph-persistent
-- location:
-    git: git@github.com:pseudonom/vector-sized
-    commit: 14ddc62a301292bf33e97b886ed5d09de5590822
-resolver: lts-5.9
+resolver: lts-8.8
 nix:
   pure: false
-extra-deps:
-  - persistent-2.5


### PR DESCRIPTION
`Data.Graph.HGraph.Persistent.TH` exports these:
```haskell
class NullableEqualityModuloFKs a where
  nullableEqualityModuloFKs :: a -> a -> Bool

couldCauseUniquenessViolation
  ::
    ( PersistEntity a
    , NullableEqualityModuloFKs (Unique a)
    )
  => a
  -> a
  -> Bool
couldCauseUniquenessViolation lhs rhs =
  or (zipWith nullableEqualityModuloFKs (persistUniqueKeys lhs) (persistUniqueKeys rhs))
```

Given the following definition:
```haskell
-- Given
share [mkPersist testSettings,  mkMigrate "testMigrate"] [persistLowerCase|
  ...
  Merp
    name Text
    bar Bool
    baz Bool
    whomp Bool Maybe
    foo FooId
    UniqueFooBarBaz foo bar baz -- A nonsensical constraint that has an FK and two plain values
    UniqueWhomp whomp !force -- A second constraint with a nullable field
    deriving Show Eq Generic
  ...
|]

mkUniquenessChecks 
```

We generate the following code:
```haskell
instance NullableEqualityModuloFKs (Unique Merp) where
  nullableEqualityModuloFKs _lhs _rhs =
    case (_lhs, _rhs) of
      (UniqueFooBarBaz _lhs1 _lhs2 _lhs3, UniqueFooBarBaz _rhs1 _rhs2 _rhs3) ->
        _lhs2 == _rhs2 && _lhs3 == _rhs3
      (UniqueWhomp _lhs1, UniqueWhomp _rhs1) ->
        maybe False id ((==) <$> _lhs1 <*> _rhs1)
      _ -> False
```

This does rely on `persistUniqueKeys` always returning the unique constructors in the same order for the same type, but I don't think there's any danger of that changing.

Additionally, we can generate checks for an individual entity's unique data instance:
```haskell
-- Make a NullableEqualityModuloFKs instance for (Unique Person) only
mkUniquenessChecksFor ''Person
```

You can use this with `mkUniquenessChecks` actually, since the latter ignores data instances for `Unique` that already have an instance of `NullableEqualityModuloFKs`.

We're using `mkUniquenessChecksFor`, but `mkUniquenessChecks` also seems useful.

Finally, we're upgrading to ghc 8.0.2 so I changed the LTS to 8.8. I knew the `DataInstD` constructor had changed, but I also had to remove the fundeps from `Ensure[Graph]Uniqueness`. In practice this isn't an issue. I didn't have to change our tests to add more type information (which kind of makes sense - any given poly-graph test is pretty explicitly typed).